### PR TITLE
Refactor equipment setup handling in moon handlers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/handlers/BloodMoonHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/handlers/BloodMoonHandler.java
@@ -38,21 +38,17 @@ public class BloodMoonHandler implements BaseHandler {
     private static final int bossStatueObjectID = GameObjects.BLOOD_MOON_STATUE_ID.getID();
     private static final WorldPoint bossLobbyLocation = Locations.BLOOD_LOBBY.getWorldPoint();
     private static final WorldPoint[] ATTACK_TILES = Locations.bloodAttackTiles();
-    private final int bossNpcID = NpcID.PMOON_BOSS_BLOOD_MOON_VIS;
     private final int sigilNpcID = GameObjects.SIGIL_NPC_ID.getID();
     private final boolean enableBoss;
     private final Rs2InventorySetup equipmentNormal;
-    private final moonsOfPerilScript script;
     private static final WorldPoint afterRainTile = Locations.BLOOD_ATTACK_6.getWorldPoint();
-    private int bloodPoolTick = -1;
     public boolean arrived = false;
     private final BossHandler boss;
     private final boolean debugLogging;
 
     public BloodMoonHandler(moonsOfPerilConfig cfg, moonsOfPerilScript script) {
         this.enableBoss = cfg.enableEclipse();
-        this.script = script;
-        this.equipmentNormal = new Rs2InventorySetup(cfg.bloodEquipmentNormal(), script.mainScheduledFuture);
+        this.equipmentNormal = script.bloodEquipment;
         this.boss = new BossHandler(cfg);
         this.debugLogging = cfg.debugLogging();
     }
@@ -74,6 +70,7 @@ public class BloodMoonHandler implements BaseHandler {
             sleepUntil(() -> Rs2Widget.isWidgetVisible(bossHealthBarWidgetID), 5_000);
         }
 
+        int bossNpcID = NpcID.PMOON_BOSS_BLOOD_MOON_VIS;
         while (Rs2Widget.isWidgetVisible(bossHealthBarWidgetID) || Rs2Npc.getNpc(bossNpcID) != null) {
             if (isSpecialAttack1Sequence()) {
                 specialAttack1Sequence();
@@ -192,7 +189,7 @@ public class BloodMoonHandler implements BaseHandler {
         int evadeCount = 0;
 
         while (isSpecialAttack1Sequence() && System.currentTimeMillis() - startMs < TIMEOUT_MS) {
-            bloodPoolTick = moonsOfPerilPlugin.bloodPoolTick;
+            int bloodPoolTick = moonsOfPerilPlugin.bloodPoolTick;
             if (debugLogging) {Microbot.log("Current tick counter: " + bloodPoolTick);}
             if (bloodPoolTick == 3) {
                 if (debugLogging) {Microbot.log("EVADE to " + evadeTile);}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/handlers/BlueMoonHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/handlers/BlueMoonHandler.java
@@ -12,7 +12,6 @@ import net.runelite.client.plugins.microbot.moonsOfPeril.moonsOfPerilConfig;
 import net.runelite.client.plugins.microbot.moonsOfPeril.moonsOfPerilScript;
 import net.runelite.client.plugins.microbot.util.Rs2InventorySetup;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
-import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
@@ -39,9 +38,7 @@ public class BlueMoonHandler implements BaseHandler {
     private static final WorldPoint[] ATTACK_TILES = Locations.blueAttackTiles();
     private static final WorldPoint AFTER_TORNADO = Locations.BLUE_ATTACK_1.getWorldPoint();
     private final int sigilNpcID = GameObjects.SIGIL_NPC_ID.getID();
-    private final int bossNpcID = NpcID.PMOON_BOSS_BLUE_MOON_VIS;
     private final Rs2InventorySetup equipmentNormal;
-    private final moonsOfPerilScript script;
     private final moonsOfPerilConfig cfg;
     private final boolean enableBoss;
     private final BossHandler boss;
@@ -49,8 +46,7 @@ public class BlueMoonHandler implements BaseHandler {
 
     public BlueMoonHandler(moonsOfPerilConfig cfg, moonsOfPerilScript script) {
         this.cfg = cfg;
-        this.script = script;
-        this.equipmentNormal = new Rs2InventorySetup(cfg.blueEquipmentNormal(), script.mainScheduledFuture);
+        this.equipmentNormal = script.blueEquipment;
         this.enableBoss = cfg.enableBlue();
         this.boss = new BossHandler(cfg);
         this.debugLogging = cfg.debugLogging();
@@ -73,6 +69,7 @@ public class BlueMoonHandler implements BaseHandler {
             boss.enterBossArena(bossName, bossStatueObjectID, bossLobbyLocation);
             sleepUntil(() -> Rs2Widget.isWidgetVisible(bossHealthBarWidgetID),5_000);
         }
+        int bossNpcID = NpcID.PMOON_BOSS_BLUE_MOON_VIS;
         while (Rs2Widget.isWidgetVisible(bossHealthBarWidgetID) || Rs2Npc.getNpc(bossNpcID) != null) {
             if (isSpecialAttack1Sequence()) {
                 specialAttack1Sequence();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/handlers/EclipseMoonHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/handlers/EclipseMoonHandler.java
@@ -38,18 +38,15 @@ public class EclipseMoonHandler implements BaseHandler {
     private static final WorldPoint cloneAttackTile = bossArenaCenter;
     private static final WorldPoint[] ATTACK_TILES = Locations.eclipseAttackTiles();
     private final int sigilNpcID = GameObjects.SIGIL_NPC_ID.getID();
-    private final int bossNpcID = NpcID.PMOON_BOSS_ECLIPSE_MOON_VIS;
     private final Rs2InventorySetup equipmentNormal;
     private final Rs2InventorySetup equipmentClones;
-    private final moonsOfPerilScript script;
     private final boolean enableBoss;
     private final BossHandler boss;
     private final boolean debugLogging;
 
     public EclipseMoonHandler(moonsOfPerilConfig cfg, moonsOfPerilScript script) {
-        this.script = script;
-        this.equipmentNormal = new Rs2InventorySetup(cfg.eclipseEquipmentNormal(), script.mainScheduledFuture);
-        this.equipmentClones = new Rs2InventorySetup(cfg.eclipseEquipmentClones(), script.mainScheduledFuture);
+        this.equipmentNormal = script.eclipseEquipment;
+        this.equipmentClones = script.eclipseClones;
         this.enableBoss = cfg.enableEclipse();
         this.boss = new BossHandler(cfg);
         this.debugLogging = cfg.debugLogging();
@@ -71,6 +68,7 @@ public class EclipseMoonHandler implements BaseHandler {
             boss.enterBossArena(bossName, bossStatueObjectID, bossLobbyLocation);
             sleepUntil(() -> Rs2Widget.isWidgetVisible(bossHealthBarWidgetID), 5_000);
         }
+        int bossNpcID = NpcID.PMOON_BOSS_ECLIPSE_MOON_VIS;
         while (Rs2Widget.isWidgetVisible(bossHealthBarWidgetID) || Rs2Npc.getNpc(bossNpcID) != null) {
             if (isSpecialAttack1Sequence()) {
                 specialAttack1Sequence();
@@ -94,10 +92,7 @@ public class EclipseMoonHandler implements BaseHandler {
      */
     public boolean isSpecialAttack1Sequence() {
         Rs2NpcModel eclipseMoonShield = Rs2Npc.getNpc(NpcID.PMOON_BOSS_ECLIPSE_MOON_SHIELD);
-        if (eclipseMoonShield != null && Rs2Npc.getNpc(sigilNpcID) == null) {
-            return true;
-        }
-        return false;
+        return eclipseMoonShield != null && Rs2Npc.getNpc(sigilNpcID) == null;
     }
 
     /**  Eclipse – Moon Shield Special-Attack Handler */
@@ -219,9 +214,8 @@ public class EclipseMoonHandler implements BaseHandler {
                 if (debugLogging) {Microbot.log("Spawn local location: " + cloneLocalLocation);}
 
                 // 3. Parry / Attack the clone
-                WorldPoint parryTile = cloneLocalLocation;
-                if (debugLogging) {Microbot.log("Clone #" + (parried + 1) + " spawned at " + cloneTrueLocation + " → Parrying via " + parryTile);}
-                Rs2Walker.walkCanvas(parryTile);
+                if (debugLogging) {Microbot.log("Clone #" + (parried + 1) + " spawned at " + cloneTrueLocation + " → Parrying via " + cloneLocalLocation);}
+                Rs2Walker.walkCanvas(cloneLocalLocation);
                 parried++;
             }
             if (!isSpecialAttack2Sequence()) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/moonsOfPerilScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/moonsOfPeril/moonsOfPerilScript.java
@@ -6,11 +6,22 @@ import net.runelite.client.plugins.microbot.Script;
 
 import net.runelite.client.plugins.microbot.moonsOfPeril.enums.State;
 import net.runelite.client.plugins.microbot.moonsOfPeril.handlers.*;
+import net.runelite.client.plugins.microbot.util.Rs2InventorySetup;
 
 import java.util.*;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class moonsOfPerilScript extends Script {
+
+    ScheduledFuture<?> getMainScheduledFuture() {
+        return mainScheduledFuture;
+    }
+    
+    public Rs2InventorySetup bloodEquipment;
+    public Rs2InventorySetup blueEquipment;
+    public Rs2InventorySetup eclipseEquipment;
+    public Rs2InventorySetup eclipseClones;
 
     @Getter
     private State state = State.IDLE;
@@ -20,6 +31,12 @@ public class moonsOfPerilScript extends Script {
     private final Map<State, BaseHandler> handlers = new EnumMap<>(State.class);
 
     public boolean run(moonsOfPerilConfig config) {
+
+        this.bloodEquipment = new Rs2InventorySetup(config.bloodEquipmentNormal(), getMainScheduledFuture());
+        this.blueEquipment = new Rs2InventorySetup(config.blueEquipmentNormal(), getMainScheduledFuture());
+        this.eclipseEquipment = new Rs2InventorySetup(config.eclipseEquipmentNormal(), getMainScheduledFuture());
+        this.eclipseClones = new Rs2InventorySetup(config.eclipseEquipmentClones(), getMainScheduledFuture());
+
         initHandlers(config);
 
         Microbot.enableAutoRunOn = false;


### PR DESCRIPTION
Moved Rs2InventorySetup instantiation from individual moon handlers to moonsOfPerilScript, passing pre-initialized equipment setups to handlers. This reduces redundant object creation and centralizes equipment management for Blood, Blue, and Eclipse moon handlers.